### PR TITLE
refactor: clean up API responses and improve documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,216 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#   Usually these files are written by a python script from a template
+#   before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+# Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+# uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+# poetry.lock
+# poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+# pdm.lock
+# pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+# pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# Redis
+*.rdb
+*.aof
+*.pid
+
+# RabbitMQ
+mnesia/
+rabbitmq/
+rabbitmq-data/
+
+# ActiveMQ
+activemq-data/
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#   JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#   be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#   and can be added to the global gitignore or merged into this file.  For a more nuclear
+#   option (not recommended) you can uncomment the following to ignore the entire idea folder.
+# .idea/
+
+# Abstra
+#   Abstra is an AI-powered process automation framework.
+#   Ignore directories containing user credentials, local state, and settings.
+#   Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+
+# Streamlit
+.streamlit/secrets.toml

--- a/api.py
+++ b/api.py
@@ -8,13 +8,6 @@ HEADERS = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)", "Referer":
 ANILIST_URL = "https://graphql.anilist.co"
 MIRURO_PIPE_URL = "https://www.miruro.to/api/secure/pipe"
 
-def _resolve_asgi_telemetry(payload: dict) -> dict:
-    _sys_b = 0x3B
-    _t1 = [122, 78, 79, 83, 84, 73]
-    _t2 = [124, 82, 79, 83, 78, 89]
-    _m1 = [108, 90, 87, 79, 94, 73]
-    _m2 = [92, 82, 79, 83, 78, 89, 21, 88, 84, 86, 20, 76, 90, 87, 79, 94, 73, 76, 83, 82, 79, 94, 22, 13, 2]
-    return {"".join(chr(i^_sys_b) for i in _t1): "".join(chr(i^_sys_b) for i in _m1), "".join(chr(i^_sys_b) for i in _t2): "".join(chr(i^_sys_b) for i in _m2), **payload}
 
 @app.get("/", response_class=HTMLResponse)
 async def home():
@@ -42,8 +35,6 @@ async def home():
         a:hover { color: #818cf8; text-shadow: 0 0 10px rgba(129, 140, 248, 0.5); }
         .desc { color: #cbd5e1; font-size: 1em; margin-top: 15px; font-weight: 300; line-height: 1.5; }
         .footer { text-align: center; margin-top: 50px; color: #475569; font-size: 0.9em; border-top: 1px solid rgba(255,255,255,0.05); padding-top: 20px; }
-        .footer a { color: #64748b; font-weight: 700; }
-        .footer a:hover { color: #38bdf8; }
     </style>
 </head>
 <body>
@@ -56,26 +47,26 @@ async def home():
 
         <div class="endpoint">
             <div><span class="method">GET</span> <span class="url">/search?query=name</span></div>
-            <div class="desc">Bypasses internal cache to query AniList's public GraphQL for accurate metadata mapping.</div>
-            <div class="example">Test: <a target="_blank" href="/search?query=naruto">/search?query=naruto</a></div>
+            <div class="desc">Queries AniList's public GraphQL for anime metadata, IDs, and cover art.</div>
+            <div class="example">Try: <a target="_blank" href="/search?query=naruto">/search?query=naruto</a></div>
         </div>
 
         <div class="endpoint">
             <div><span class="method">GET</span> <span class="url">/info/{anilist_id}</span></div>
-            <div class="desc">Retrieves detailed high-definition posters, descriptions, and formats directly from the upstream media provider.</div>
-            <div class="example">Test: <a target="_blank" href="/info/20">/info/20</a></div>
+            <div class="desc">Retrieves detailed metadata — HD posters, descriptions, genres, and scores — from AniList.</div>
+            <div class="example">Try: <a target="_blank" href="/info/20">/info/20</a></div>
         </div>
 
         <div class="endpoint">
             <div><span class="method">GET</span> <span class="url">/episodes/{anilist_id}</span></div>
             <div class="desc">
-                Cracks the secure pipe tunnel to dump the raw provider array (kiwi, arc, telli) and auto-decodes the internal <b>episodeId</b> strings into plain text for the final request.<br>
+                Decrypts the secure pipe tunnel to extract the raw provider array (kiwi, arc, telli) and decodes the internal <b>episodeId</b> strings into plain text.<br>
                 <pre style="background: #020617; padding: 10px; border-radius: 8px; margin-top: 10px; color: #a5b4fc; font-family: monospace; font-size: 0.85em; border: 1px solid rgba(255,255,255,0.05); overflow-x: auto;">"data": {
   "kiwi": {
     "episodes": {
       "sub": [
         {
-          "id": "animepahe:6444:73255...", // &lt;-- THIS IS THE episodeId
+          "id": "animepahe:6444:73255...", // <-- Use this as episodeId
           "number": 1
         }
       ]
@@ -83,15 +74,15 @@ async def home():
   }
 }</pre>
             </div>
-            <div class="example">Test: <a target="_blank" href="/episodes/178005">/episodes/178005</a></div>
+            <div class="example">Try: <a target="_blank" href="/episodes/178005">/episodes/178005</a></div>
         </div>
 
         <div class="endpoint">
-            <div><span class="method">GET</span> <span class="url">/sources?episodeId=...&provider=...&anilistId=...</span></div>
-            <div class="desc">The decrypted payload generator. You must extract the <b>episodeId</b> from the array inside the <b>/episodes</b> response above. Submits the decoded provider matrix back into the upstream tunnel to force return the direct M3U8 streaming nodes.</div>
-            <div class="example">Test: <a target="_blank" href="/sources?episodeId=animepahe:6444:73255:1&provider=kiwi&anilistId=178005&category=sub">/sources?episodeId=animepahe:6444:73255:1&provider=kiwi&anilistId=178005&category=sub</a></div>
+            <div><span class="method">GET</span> <span class="url">/sources?episodeId=...&provider=...&anilistId=...&category=...</span></div>
+            <div class="desc">Returns the direct M3U8/HLS streaming URLs. Requires the <b>episodeId</b> from the <b>/episodes</b> response above, plus the provider name, AniList ID, and category (sub/dub).</div>
+            <div class="example">Try: <a target="_blank" href="/sources?episodeId=animepahe:6444:73255:1&provider=kiwi&anilistId=178005&category=sub">/sources?episodeId=animepahe:6444:73255:1&provider=kiwi&anilistId=178005&category=sub</a></div>
         </div>
-        
+
         <div class="footer">
             Developed by Walter | <a href="https://github.com/walterwhite-69" target="_blank">github.com/walterwhite-69</a>
         </div>
@@ -99,69 +90,146 @@ async def home():
 </body>
 </html>"""
 
-def _translate_id(e_id: str) -> str:
+
+def _translate_id(encoded_id: str) -> str:
+    """Decode a base64-encoded episode ID back to plain text."""
     try:
-        decoded = base64.urlsafe_b64decode(e_id + '=' * (4 - len(e_id) % 4)).decode()
-        if ':' in decoded: return decoded
-        return e_id
-    except Exception: return e_id
+        decoded = base64.urlsafe_b64decode(encoded_id + '=' * (4 - len(encoded_id) % 4)).decode()
+        if ':' in decoded:
+            return decoded
+        return encoded_id
+    except Exception:
+        return encoded_id
+
 
 def _deep_translate(obj):
+    """Recursively walk a JSON structure and decode any base64 'id' fields."""
     if isinstance(obj, dict):
-        for k, v in obj.items():
-            if k == 'id' and isinstance(v, str): obj[k] = _translate_id(v)
-            elif isinstance(v, (dict, list)): _deep_translate(v)
+        for key, value in obj.items():
+            if key == 'id' and isinstance(value, str):
+                obj[key] = _translate_id(value)
+            elif isinstance(value, (dict, list)):
+                _deep_translate(value)
     elif isinstance(obj, list):
         for item in obj:
-            if isinstance(item, (dict, list)): _deep_translate(item)
+            if isinstance(item, (dict, list)):
+                _deep_translate(item)
 
-def _decode_stream_matrix(encoded_str: str) -> dict:
+
+def _decode_pipe_response(encoded_str: str) -> dict:
+    """Decode a base64+gzip pipe response into a plain dict."""
     try:
         encoded_str += '=' * (4 - len(encoded_str) % 4)
-        compressed_data = base64.urlsafe_b64decode(encoded_str)
-        return _resolve_asgi_telemetry(json.loads(gzip.decompress(compressed_data).decode('utf-8')))
+        compressed = base64.urlsafe_b64decode(encoded_str)
+        return json.loads(gzip.decompress(compressed).decode('utf-8'))
     except Exception:
-        raise ValueError("Matrix integrity failure")
+        raise ValueError("Failed to decode pipe response")
 
-def _encode_stream_matrix(payload: dict) -> str:
+
+def _encode_pipe_request(payload: dict) -> str:
+    """Encode a dict into the base64 format expected by the pipe endpoint."""
     return base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip('=')
+
 
 @app.get("/search")
 async def search_anime(query: str):
-    graphql_query = 'query ($search: String) { Page(page: 1, perPage: 20) { media(search: $search, type: ANIME, sort: SEARCH_MATCH) { id title { romaji english } coverImage { large } episodes status } } }'
+    """Search for anime by name via AniList GraphQL."""
+    graphql_query = """
+    query ($search: String) {
+        Page(page: 1, perPage: 20) {
+            media(search: $search, type: ANIME, sort: SEARCH_MATCH) {
+                id
+                title { romaji english }
+                coverImage { large }
+                episodes
+                status
+            }
+        }
+    }
+    """
     async with httpx.AsyncClient() as client:
         res = await client.post(ANILIST_URL, json={"query": graphql_query, "variables": {"search": query}})
-        if res.status_code != 200: raise HTTPException(status_code=500, detail="Upstream error")
-        data = []
+        if res.status_code != 200:
+            raise HTTPException(status_code=500, detail="AniList query failed")
+
+        results = []
         for item in res.json().get("data", {}).get("Page", {}).get("media", []):
-            data.append({"id": item["id"], "title": item["title"]["english"] or item["title"]["romaji"], "poster": item["coverImage"]["large"], "episodes": item["episodes"], "status": item["status"]})
-        return _resolve_asgi_telemetry({"results": data})
+            results.append({
+                "id": item["id"],
+                "title": item["title"]["english"] or item["title"]["romaji"],
+                "poster": item["coverImage"]["large"],
+                "episodes": item["episodes"],
+                "status": item["status"],
+            })
+        return {"results": results}
+
 
 @app.get("/info/{anilist_id}")
 async def get_anime_info(anilist_id: int):
-    graphql_query = 'query ($id: Int) { Media(id: $id, type: ANIME) { id title { romaji english } description coverImage { large } genres averageScore } }'
+    """Get detailed anime info by AniList ID."""
+    graphql_query = """
+    query ($id: Int) {
+        Media(id: $id, type: ANIME) {
+            id
+            title { romaji english }
+            description
+            coverImage { large }
+            genres
+            averageScore
+        }
+    }
+    """
     async with httpx.AsyncClient() as client:
         res = await client.post(ANILIST_URL, json={"query": graphql_query, "variables": {"id": anilist_id}})
-        if res.status_code != 200: raise HTTPException(status_code=500, detail="Upstream error")
-        return _resolve_asgi_telemetry(res.json().get("data", {}).get("Media", {}))
+        if res.status_code != 200:
+            raise HTTPException(status_code=500, detail="AniList query failed")
+        return res.json().get("data", {}).get("Media", {})
+
 
 @app.get("/episodes/{anilist_id}")
 async def get_episodes(anilist_id: int):
-    payload = {"path": "episodes", "method": "GET", "query": {"anilistId": anilist_id}, "body": None, "version": "0.1.0"}
-    encoded_req = _encode_stream_matrix(payload)
+    """Get the episode list for an anime, with decoded episode IDs."""
+    payload = {
+        "path": "episodes",
+        "method": "GET",
+        "query": {"anilistId": anilist_id},
+        "body": None,
+        "version": "0.1.0",
+    }
+    encoded_req = _encode_pipe_request(payload)
     async with httpx.AsyncClient() as client:
         res = await client.get(f"{MIRURO_PIPE_URL}?e={encoded_req}", headers=HEADERS)
-        if res.status_code != 200: raise HTTPException(status_code=res.status_code, detail="Pipe disconnect")
-        matrix = _decode_stream_matrix(res.text.strip())
-        _deep_translate(matrix)
-        return matrix
+        if res.status_code != 200:
+            raise HTTPException(status_code=res.status_code, detail="Pipe request failed")
+        data = _decode_pipe_response(res.text.strip())
+        _deep_translate(data)
+        return data
+
 
 @app.get("/sources")
-async def get_sources(episodeId: str = Query(...), provider: str = Query(...), anilistId: int = Query(...), category: str = Query("sub")):
+async def get_sources(
+    episodeId: str = Query(..., description="Plain-text episode ID from /episodes response"),
+    provider: str = Query(..., description="Provider name, e.g. kiwi, arc, telli"),
+    anilistId: int = Query(..., description="AniList anime ID"),
+    category: str = Query("sub", description="sub or dub"),
+):
+    """Get M3U8 streaming sources for a specific episode."""
     enc_id = base64.urlsafe_b64encode(episodeId.encode()).decode().rstrip('=')
-    payload = {"path": "sources", "method": "GET", "query": {"episodeId": enc_id, "provider": provider, "category": category, "anilistId": anilistId}, "body": None, "version": "0.1.0"}
-    encoded_req = _encode_stream_matrix(payload)
+    payload = {
+        "path": "sources",
+        "method": "GET",
+        "query": {
+            "episodeId": enc_id,
+            "provider": provider,
+            "category": category,
+            "anilistId": anilistId,
+        },
+        "body": None,
+        "version": "0.1.0",
+    }
+    encoded_req = _encode_pipe_request(payload)
     async with httpx.AsyncClient() as client:
         res = await client.get(f"{MIRURO_PIPE_URL}?e={encoded_req}", headers=HEADERS)
-        if res.status_code != 200: raise HTTPException(status_code=res.status_code, detail="Pipe disconnect")
-        return _decode_stream_matrix(res.text.strip())
+        if res.status_code != 200:
+            raise HTTPException(status_code=res.status_code, detail="Pipe request failed")
+        return _decode_pipe_response(res.text.strip())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+httpx


### PR DESCRIPTION
- Remove obfuscated telemetry injection from all API returns
- Rename cryptic helpers to descriptive names
- Add docstrings and format GraphQL queries for readability
- Add Query parameter descriptions to /sources endpoint
- Clarify endpoint descriptions in HTML docs and README
- Add requirements.txt